### PR TITLE
Run the project in a docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ docs/site/
 # committed for packages, but should be committed for applications that require a static
 # environment.
 Manifest.toml
+
+# Files for generation
+data/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+BUILD_DIR := $(PWD)/build
+
+build:
+	@docker run -it --rm -v $(PWD):/src -v $(BUILD_DIR):/root/.julia/  -w /src julia julia ./build.jl
+
+run: build
+	@docker run -it --rm -v $(PWD):/src -v $(BUILD_DIR):/root/.julia/  -w /src julia julia ./run.jl
+
+clean:
+	rm -r $(BUILD_DIR)

--- a/README.md
+++ b/README.md
@@ -4,13 +4,40 @@ This repo is for generating 3D surface meshes that project caustic images. It is
 
 See the write-up [here](https://mattferraro.dev/posts/caustics-engineering)!
 
-# To Run
+# To Run from source
 
 To run the cat example from the blogpost, run line by line from ` src/scratchpad.jl`.
 
 _OR_ from the command line.
 
 ```
-julia ./run.jl"
+julia ./run.jl
 ```
 The image file is currently hard-coded.
+
+# To Run in docker
+
+In this case you don't have install Julia locally - instead you will be able to build and run the project in a docker container.
+To do that, follow the guide:
+
+1. Put your source image to `data/input.jpg`. This is the file the project will process.
+1. Clean your build (you can omit this step if you are running the code for the first time).
+It is required if you modify your source code only (changing input image doesn't require to execute this step):
+
+    ```sh
+    make clean 
+    ```
+
+1. Build the project:
+
+    ```sh
+    make build
+    ```
+
+1. Run the project:
+
+    ```sh
+    make run
+    ```
+
+1. Find your output in `data/output.obj`.

--- a/build.jl
+++ b/build.jl
@@ -1,0 +1,4 @@
+using Pkg
+Pkg.activate(".")
+Pkg.instantiate()
+

--- a/run.jl
+++ b/run.jl
@@ -1,6 +1,5 @@
 using Pkg
 Pkg.activate(".")
-Pkg.instantiate()
 
 using Images, CausticsEngineering
 

--- a/run.jl
+++ b/run.jl
@@ -1,7 +1,10 @@
 using Pkg
 Pkg.activate(".")
+Pkg.instantiate()
 
 using Images, CausticsEngineering
 
-image = Images.load("./examples/cat_posing.jpg") # Check current working directory with pwd()
+const input_file = "./data/input.jpg"
+
+image = Images.load(input_file) # Check current working directory with pwd()
 engineer_caustics(image);

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,1 @@
+docker run -it --rm -v $(pwd):/src  -w /src julia julia ./run.jl

--- a/run.sh
+++ b/run.sh
@@ -1,1 +1,0 @@
-docker run -it --rm -v $(pwd):/src  -w /src julia julia ./run.jl

--- a/src/create_mesh.jl
+++ b/src/create_mesh.jl
@@ -1,5 +1,6 @@
 # Currently unused.
 const grid_definition = 512
+const output_file = "./data/output.obj"
 
 
 """
@@ -931,7 +932,7 @@ function engineer_caustics(img)
     solidMesh = solidify(meshy)
     saveObj!(
         solidMesh,
-        "./examples/original_image.obj",
+        output_file,
         scale=1 / 512 * artifactSize,
         scalez=1 / 512.0 * artifactSize,
     )


### PR DESCRIPTION
- Split the executable into build and run phases.
- Added Makefile with `clean`, `build` and `run` targets.
- Run the project in a Julia docker container - this allows to omit to install Julia locally.